### PR TITLE
Fix "uninitialized constant Gem::Platform::Ruby" error

### DIFF
--- a/indicator.gemspec
+++ b/indicator.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = 'Higher level wrapper around the talib_ruby project'
   s.author = 'Michael Lamb'
   s.email = 'mr.lamby@gmail.com'
-  s.platform = Gem::Platform::Ruby
+  s.platform = Gem::Platform::RUBY
   s.homepage = 'https://github.com/mlamby/indicator'
   s.files = %w(LICENSE LICENSE-ta-lib README.rdoc Rakefile) + Dir["{lib,examples}/**/*"]
   s.test_files = Dir["test/**/*"]


### PR DESCRIPTION
Even though the [official doc](http://docs.rubygems.org/read/chapter/20#platform) says that Gem::Platform::Ruby is the default value, it fails on Linux (with Ruby 1.9.3) and Mac. Gem::Platform::RUBY, however works.
