### PR TITLE
Change direction of slashes in list_template.erb

### DIFF
--- a/tools/list_template.erb
+++ b/tools/list_template.erb
@@ -4,5 +4,5 @@ module Indicator
 end
 
 <% functions.each do |f| %>
-require 'indicator\auto_gen\<%=f.camel_name.underscore%>'
+require 'indicator/auto_gen/<%=f.camel_name.underscore%>'
 <%end%>


### PR DESCRIPTION
The Windows-style slashes caused autogen.rb's requires to fail on Linux. The problem shouldn't recur any more now that the template is fixed.

I haven't committed the regenerated files because there's some kind of line ending conflict I can't figure out.
